### PR TITLE
fix(cluster): add database type check for legacy GPDB query

### DIFF
--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -577,7 +577,7 @@ func GetSegmentConfiguration(connection *dbconn.DBConn, getMirrors ...bool) ([]S
 	includeMirrors := len(getMirrors) == 1 && getMirrors[0]
 	includeOnlyMirrors := len(getMirrors) == 2 && getMirrors[1]
 	query := ""
-	if connection.Version.Before("6") {
+	if connection.Version.IsGPDB() && connection.Version.Before("6") {
 		whereClause := "WHERE%s f.fsname = 'pg_system'"
 		if includeOnlyMirrors {
 			whereClause = fmt.Sprintf(whereClause, " s.role = 'm' AND")


### PR DESCRIPTION
When retrieving the segment configuration, there is special query logic for Greenplum Database (GPDB) versions prior to "6".

The previous implementation only checked the version number. This could cause an incorrect query to be executed on a non-GPDB database (like CloudberryDB) that might also satisfy the `Before("6")` version check.

This commit adds an `IsGPDB()` check to ensure this legacy logic is triggered only when connected to the correct database type, making the function more robust.