### PR TITLE
Add gp-common-go-libs file inventory to LICENSE for release compliance

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -199,3 +199,58 @@
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
+
+================================================================================
+This product includes software from Greenplum Database Common Go Libraries,
+under Apache 2.0 license:
+
+ Greenplum Database Common Go Libraries
+ (https://github.com/greenplum-db/gp-common-go-libs)
+
+Copyright 2017-Present VMware, Inc. or its affiliates. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+The Greenplum Database Common Go Libraries software includes:
+- cluster/cluster.go
+- cluster/cluster_test.go
+- conv/const.go
+- conv/conv_suite_test.go
+- conv/float.go
+- conv/float_test.go
+- conv/int.go
+- conv/int_test.go
+- conv/md5.go
+- conv/md5_test.go
+- conv/README.md
+- conv/uint.go
+- conv/uint_test.go
+- dbconn/dbconn.go
+- dbconn/dbconn_test.go
+- dbconn/version.go
+- dbconn/version_test.go
+- gperror/gperror.go
+- gperror/gperror_test.go
+- gplog/gplog.go
+- gplog/gplog_test.go
+- iohelper/iohelper.go
+- iohelper/iohelper_test.go
+- operating/operating.go
+- structmatcher/structmatcher.go
+- structmatcher/structmatcher_test.go
+- testhelper/functions.go
+- testhelper/structs.go
+- Makefile
+- go.mod
+- go.sum
+- show_coverage.sh


### PR DESCRIPTION
Append a section at the bottom of the LICENSE file that lists all files originating from the Greenplum Database Common Go Libraries (gp-common-go-libs) project, following the same pattern used in apache/cloudberry-backup.

The file list can be a reference for Incubator PMC members for license compliance review.

<!--Thank you for contributing! -->

<!--In case of an existing issue or discussions, please reference it-->
closes: #ISSUE_Number
<!--Remove this section if no corresponding issue.-->

---

## Change logs

> Describe your change clearly, including what problem is being solved or what document is being added or updated.

## Contributor's checklist

Here are some reminders before you submit your pull request:

* Make sure that your Pull Request has a clear title and commit message. You can take the [Git commit template](https://github.com/apache/cloudberry/blob/main/.gitmessage) as a reference.
* Learn the [code contribution](https://cloudberry.apache.org/contribute/code) and [doc contribution](https://cloudberry.apache.org/contribute/doc) guides for better collaboration.
* Make sure that CICD workflow is successful.
* List your communications in the [GitHub Issues](https://github.com/apache/cloudberry-go-libs/issues) or [Discussions](https://github.com/apache/cloudberry/discussions) (if has or needed).
* Feel free to ask for the [cloudberry committers](https://github.com/orgs/apache/teams/cloudberry-committers) or other people to help review and approve.